### PR TITLE
Remove conda build dependency on setupPython

### DIFF
--- a/src/main/java/com/palantir/python/miniconda/MinicondaPlugin.java
+++ b/src/main/java/com/palantir/python/miniconda/MinicondaPlugin.java
@@ -54,7 +54,7 @@ public class MinicondaPlugin implements Plugin<Project> {
         TaskContainer tasks = project.getTasks();
         BootstrapPython bootstrapPython = BootstrapPython.createTask(tasks);
         SetupPython setupPython = SetupPython.createTask(tasks, bootstrapPython);
-        SetupCondaBuild setupCondaBuild = SetupCondaBuild.createTask(tasks, setupPython);
+        SetupCondaBuild setupCondaBuild = SetupCondaBuild.createTask(tasks, bootstrapPython);
         CondaBuildCheck condaBuildCheck = CondaBuildCheck.createTask(tasks, setupCondaBuild);
         CondaBuild condaBuild = CondaBuild.createTask(tasks, condaBuildCheck);
 

--- a/src/main/java/com/palantir/python/miniconda/tasks/CondaBuild.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/CondaBuild.java
@@ -55,7 +55,7 @@ public class CondaBuild extends AbstractExecTask<CondaBuild> {
     public void configureAfterEvaluate(final MinicondaExtension miniconda) {
         Objects.requireNonNull(miniconda, "miniconda must not be null");
 
-        executable(miniconda.getBuildEnvironmentDirectory().toPath().resolve("bin/conda"));
+        executable(miniconda.getBootstrapDirectory().toPath().resolve("bin/conda"));
         args("build", miniconda.getMetaYaml());
         args("--override-channels");
         args("--no-anaconda-upload");

--- a/src/main/java/com/palantir/python/miniconda/tasks/CondaBuildCheck.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/CondaBuildCheck.java
@@ -54,7 +54,7 @@ public class CondaBuildCheck extends AbstractExecTask<CondaBuildCheck> {
     public void configureAfterEvaluate(final MinicondaExtension miniconda) {
         Objects.requireNonNull(miniconda, "miniconda must not be null");
 
-        executable(miniconda.getBuildEnvironmentDirectory().toPath().resolve("bin/conda"));
+        executable(miniconda.getBootstrapDirectory().toPath().resolve("bin/conda"));
         args("build", miniconda.getMetaYaml());
         args("--check");
 

--- a/src/main/java/com/palantir/python/miniconda/tasks/SetupCondaBuild.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/SetupCondaBuild.java
@@ -42,14 +42,14 @@ public class SetupCondaBuild extends AbstractExecTask<SetupCondaBuild> {
     private static final String DEFAULT_GROUP = "build";
     private static final String DEFAULT_DESCRIPTION = "Installs conda-build.";
 
-    public static SetupCondaBuild createTask(TaskContainer tasks, SetupPython setupPython) {
+    public static SetupCondaBuild createTask(TaskContainer tasks, BootstrapPython bootstrapPython) {
         Objects.requireNonNull(tasks, "tasks must not be null");
-        Objects.requireNonNull(setupPython, "setupPython must not be null");
+        Objects.requireNonNull(bootstrapPython, "bootstrapPython must not be null");
 
         SetupCondaBuild task = tasks.create("setupCondaBuild", SetupCondaBuild.class);
         task.setGroup(DEFAULT_GROUP);
         task.setDescription(DEFAULT_DESCRIPTION);
-        task.dependsOn(setupPython);
+        task.dependsOn(bootstrapPython);
 
         CleanTaskUtils.createCleanupTask(tasks, task);
         return task;

--- a/src/test/groovy/com/palantir/python/miniconda/MinicondaBuildTest.groovy
+++ b/src/test/groovy/com/palantir/python/miniconda/MinicondaBuildTest.groovy
@@ -63,7 +63,6 @@ class MinicondaBuildTest extends Specification {
         LOG.info(result.getOutput())
 
         then:
-        result.task(":setupPython").outcome == TaskOutcome.SUCCESS
         result.task(":condaBuild").outcome == TaskOutcome.SUCCESS
 
         FileUtils.listFiles(


### PR DESCRIPTION
Conda build can only be installed in the root conda installation and conda build creates its own environment anyway. There is therefore no need to run setupPython as part of the condaBuild process.