### PR TITLE
Do not allow install to update deps

### DIFF
--- a/src/main/java/com/palantir/python/miniconda/tasks/SetupCondaBuild.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/SetupCondaBuild.java
@@ -68,7 +68,7 @@ public class SetupCondaBuild extends AbstractExecTask<SetupCondaBuild> {
 
         final Path condaExec = miniconda.getBootstrapDirectory().toPath().resolve("bin/conda");
         executable(condaExec);
-        args("install", "--quiet", "--yes", "--override-channels");
+        args("install", "--quiet", "--yes", "--override-channels", "--no-update-dependencies");
         args(MinicondaUtils.convertChannelsToArgs(miniconda.getChannels()));
 
         if (miniconda.getCondaBuildVersion() != null) {

--- a/src/main/java/com/palantir/python/miniconda/tasks/SetupCondaBuild.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/SetupCondaBuild.java
@@ -68,7 +68,7 @@ public class SetupCondaBuild extends AbstractExecTask<SetupCondaBuild> {
 
         final Path condaExec = miniconda.getBootstrapDirectory().toPath().resolve("bin/conda");
         executable(condaExec);
-        args("install", "--quiet", "--yes", "--override-channels", "--no-update-dependencies");
+        args("install", "--quiet", "--yes", "--override-channels", "--no-update-deps");
         args(MinicondaUtils.convertChannelsToArgs(miniconda.getChannels()));
 
         if (miniconda.getCondaBuildVersion() != null) {

--- a/src/main/java/com/palantir/python/miniconda/tasks/SetupPython.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/SetupPython.java
@@ -63,7 +63,7 @@ public class SetupPython extends AbstractExecTask<SetupPython> {
 
         executable(miniconda.getBootstrapDirectory().toPath().resolve("bin/conda"));
         args("create", "--yes", "--quiet", "-p", miniconda.getBuildEnvironmentDirectory());
-        args("--override-channels", "--no-update-dependencies");
+        args("--override-channels", "--no-update-deps");
         args(MinicondaUtils.convertChannelsToArgs(miniconda.getChannels()));
         args(miniconda.getPackages());
 

--- a/src/main/java/com/palantir/python/miniconda/tasks/SetupPython.java
+++ b/src/main/java/com/palantir/python/miniconda/tasks/SetupPython.java
@@ -63,7 +63,7 @@ public class SetupPython extends AbstractExecTask<SetupPython> {
 
         executable(miniconda.getBootstrapDirectory().toPath().resolve("bin/conda"));
         args("create", "--yes", "--quiet", "-p", miniconda.getBuildEnvironmentDirectory());
-        args("--override-channels");
+        args("--override-channels", "--no-update-dependencies");
         args(MinicondaUtils.convertChannelsToArgs(miniconda.getChannels()));
         args(miniconda.getPackages());
 


### PR DESCRIPTION
When conda-build is installed, it depends on conda, so a setupCondaBuild can actually modify the conda version on disk.